### PR TITLE
Add moveable empty end portal frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ A full end portal frame will drop an eye of ender when right clicked by a player
 - Required options: `true`, `false`
 - Categories: `FEATURE`, `EXPERIMENTAL`, `GILLY7CE-CARPET-ADDON`
 
+### movableEmptyEndPortalFrames
+
+Allows empty end portal frames to be moved.
+
+- Type: `boolean`
+- Default value: `false`
+- Required options: `true`, `false`
+- Categories: `FEATURE`, `EXPERIMENTAL`, `GILLY7CE-CARPET-ADDON`
+
 ### netheriteAxeInstantMineWood
 
 A netherite axe with efficiency V combined with the haste II status effect will instant mine wood and nether wood type blocks.

--- a/src/main/java/gillycarpetaddons/GillyCarpetAddonsSettings.java
+++ b/src/main/java/gillycarpetaddons/GillyCarpetAddonsSettings.java
@@ -13,7 +13,7 @@ public class GillyCarpetAddonsSettings {
     public static boolean dropEyesOfEnderFromEndPortalFrame = false;
 
     @Rule(categories = {FEATURE, EXPERIMENTAL, GILLY})
-    public static boolean movableEndPortalFrames = false;
+    public static boolean movableEmptyEndPortalFrames = false;
   
     @Rule(categories = {SURVIVAL, GILLY})
     public static boolean netheriteAxeInstantMineWood = false;

--- a/src/main/java/gillycarpetaddons/GillyCarpetAddonsSettings.java
+++ b/src/main/java/gillycarpetaddons/GillyCarpetAddonsSettings.java
@@ -11,6 +11,9 @@ public class GillyCarpetAddonsSettings {
     
     @Rule(categories = {FEATURE, EXPERIMENTAL, GILLY})
     public static boolean dropEyesOfEnderFromEndPortalFrame = false;
+
+    @Rule(categories = {FEATURE, EXPERIMENTAL, GILLY})
+    public static boolean movableEndPortalFrames = false;
   
     @Rule(categories = {SURVIVAL, GILLY})
     public static boolean netheriteAxeInstantMineWood = false;

--- a/src/main/java/gillycarpetaddons/mixins/PistonBlock_MovableEmptyEndPortalFrameMixin.java
+++ b/src/main/java/gillycarpetaddons/mixins/PistonBlock_MovableEmptyEndPortalFrameMixin.java
@@ -9,7 +9,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(PistonBlock.class)
-public class PistonBlock_MovableEndPortalFrameMixin {
+public class PistonBlock_MovableEmptyEndPortalFrameMixin {
     @Redirect(
             method = "isMovable",
             at = @At(
@@ -19,7 +19,7 @@ public class PistonBlock_MovableEndPortalFrameMixin {
     private static float getHardnessRedirect(BlockState instance, BlockView blockView, BlockPos blockPos) {
         Block currentBlock = instance.getBlock();
         // Only allow empty end portal frames to be moved
-        if (GillyCarpetAddonsSettings.movableEndPortalFrames
+        if (GillyCarpetAddonsSettings.movableEmptyEndPortalFrames
                 && currentBlock == Blocks.END_PORTAL_FRAME
                 && !instance.get(EndPortalFrameBlock.EYE)) {
             // If hardness is -1.0f then the piston cannot be moved. This is the vanilla behaviour for end portal frames

--- a/src/main/java/gillycarpetaddons/mixins/PistonBlock_MovableEndPortalFrameMixin.java
+++ b/src/main/java/gillycarpetaddons/mixins/PistonBlock_MovableEndPortalFrameMixin.java
@@ -1,0 +1,33 @@
+package gillycarpetaddons.mixins;
+
+import gillycarpetaddons.GillyCarpetAddonsSettings;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.PistonBlock;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.BlockView;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(PistonBlock.class)
+public class PistonBlock_MovableEndPortalFrameMixin {
+    @Redirect(
+            method = "isMovable",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/block/BlockState;getHardness(Lnet/minecraft/world/BlockView;Lnet/minecraft/util/math/BlockPos;)F"
+            ))
+    private static float getHardnessRedirect(BlockState instance, BlockView blockView, BlockPos blockPos) {
+        Block currentBlock = instance.getBlock();
+        if (GillyCarpetAddonsSettings.movableEndPortalFrames && currentBlock == Blocks.END_PORTAL_FRAME) {
+            // If hardness is -1.0f then the piston cannot be moved. This is the vanilla behaviour for end portal frames
+            // which matches with the bedrock block. Instead of overriding the hardness for end portal frames everywhere,
+            // just do it when it is called inside the PistonBlock.
+            return 0f;
+        }
+
+        return instance.getHardness(blockView, blockPos);
+    }
+}

--- a/src/main/java/gillycarpetaddons/mixins/PistonBlock_MovableEndPortalFrameMixin.java
+++ b/src/main/java/gillycarpetaddons/mixins/PistonBlock_MovableEndPortalFrameMixin.java
@@ -1,10 +1,7 @@
 package gillycarpetaddons.mixins;
 
 import gillycarpetaddons.GillyCarpetAddonsSettings;
-import net.minecraft.block.Block;
-import net.minecraft.block.BlockState;
-import net.minecraft.block.Blocks;
-import net.minecraft.block.PistonBlock;
+import net.minecraft.block.*;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.BlockView;
 import org.spongepowered.asm.mixin.Mixin;
@@ -21,7 +18,10 @@ public class PistonBlock_MovableEndPortalFrameMixin {
             ))
     private static float getHardnessRedirect(BlockState instance, BlockView blockView, BlockPos blockPos) {
         Block currentBlock = instance.getBlock();
-        if (GillyCarpetAddonsSettings.movableEndPortalFrames && currentBlock == Blocks.END_PORTAL_FRAME) {
+        // Only allow empty end portal frames to be moved
+        if (GillyCarpetAddonsSettings.movableEndPortalFrames
+                && currentBlock == Blocks.END_PORTAL_FRAME
+                && !instance.get(EndPortalFrameBlock.EYE)) {
             // If hardness is -1.0f then the piston cannot be moved. This is the vanilla behaviour for end portal frames
             // which matches with the bedrock block. Instead of overriding the hardness for end portal frames everywhere,
             // just do it when it is called inside the PistonBlock.

--- a/src/main/resources/assets/gilly7ce-carpet-addons/lang/en_us.json
+++ b/src/main/resources/assets/gilly7ce-carpet-addons/lang/en_us.json
@@ -1,6 +1,7 @@
 {
   "carpet.category.gilly7ce_carpet_addons": "gilly7ce-carpet-addons",
   "carpet.rule.dropEyesOfEnderFromEndPortalFrame.desc": "A full end portal frame will drop an eye of ender when right clicked by a player, turning into an empty end portal frame in the process. Any connecting end portals will break.",
+  "carpet.rule.movableEndPortalFrames.desc" : "Allows end portal frames to be moved.\nThis only works for empty portal frames.",
   "carpet.rule.netheriteAxeInstantMineWood.desc": "A netherite axe with efficiency V combined with the haste II status effect will instant mine wood and nether wood type blocks.",
   "carpet.rule.netheritePickaxeInstantMineBlueIce.desc": "A netherite pickaxe with efficiency V combined with the haste II status effect will instant mine blue ice blocks.",
   "carpet.rule.netheritePickaxeInstantMineCobblestone.desc": "A netherite pickaxe with efficiency V combined with the haste II status effect will instant mine cobblestone type blocks.",

--- a/src/main/resources/assets/gilly7ce-carpet-addons/lang/en_us.json
+++ b/src/main/resources/assets/gilly7ce-carpet-addons/lang/en_us.json
@@ -1,7 +1,7 @@
 {
   "carpet.category.gilly7ce_carpet_addons": "gilly7ce-carpet-addons",
   "carpet.rule.dropEyesOfEnderFromEndPortalFrame.desc": "A full end portal frame will drop an eye of ender when right clicked by a player, turning into an empty end portal frame in the process. Any connecting end portals will break.",
-  "carpet.rule.movableEndPortalFrames.desc" : "Allows end portal frames to be moved.\nThis only works for empty portal frames.",
+  "carpet.rule.movableEmptyEndPortalFrames.desc": "Allows empty end portal frames to be moved.",
   "carpet.rule.netheriteAxeInstantMineWood.desc": "A netherite axe with efficiency V combined with the haste II status effect will instant mine wood and nether wood type blocks.",
   "carpet.rule.netheritePickaxeInstantMineBlueIce.desc": "A netherite pickaxe with efficiency V combined with the haste II status effect will instant mine blue ice blocks.",
   "carpet.rule.netheritePickaxeInstantMineCobblestone.desc": "A netherite pickaxe with efficiency V combined with the haste II status effect will instant mine cobblestone type blocks.",

--- a/src/main/resources/gilly7ce-carpet-addons.mixins.json
+++ b/src/main/resources/gilly7ce-carpet-addons.mixins.json
@@ -6,6 +6,7 @@
     "AbstractClientPlayerEntity_InstantMineMixin",
     "EndFrameBlock_EyeToggleMixin",
     "PhantomSpawner_PhantomsObeyHostileMobCapMixin",
+    "PistonBlock_MovableEndPortalFrameMixin",
     "ServerChunkManager_PhantomsObeyHostileMobCapMixin",
     "ServerPlayerEntity_InstantMineMixin",
     "invokers.SpawnHelperInfoInvokerMixin"

--- a/src/main/resources/gilly7ce-carpet-addons.mixins.json
+++ b/src/main/resources/gilly7ce-carpet-addons.mixins.json
@@ -6,7 +6,7 @@
     "AbstractClientPlayerEntity_InstantMineMixin",
     "EndFrameBlock_EyeToggleMixin",
     "PhantomSpawner_PhantomsObeyHostileMobCapMixin",
-    "PistonBlock_MovableEndPortalFrameMixin",
+    "PistonBlock_MovableEmptyEndPortalFrameMixin",
     "ServerChunkManager_PhantomsObeyHostileMobCapMixin",
     "ServerPlayerEntity_InstantMineMixin",
     "invokers.SpawnHelperInfoInvokerMixin"


### PR DESCRIPTION
End portal frames are now movable with the rule `movableEmptyEndPortalFrames`.

Closes #19 