### PR TITLE
Add movableSpawners rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ Allows empty end portal frames to be moved.
 - Required options: `true`, `false`
 - Categories: `FEATURE`, `EXPERIMENTAL`, `GILLY7CE-CARPET-ADDON`
 
+### movableSpawners
+
+Allows spawners to be moved.
+This requires the carpet `movableBlockEntities` rule to be enabled.
+
+- Type: `boolean`
+- Default value: `false`
+- Required options: `true`, `false`
+- Categories: `FEATURE`, `EXPERIMENTAL`, `GILLY7CE-CARPET-ADDON`
+
 ### netheriteAxeInstantMineWood
 
 A netherite axe with efficiency V combined with the haste II status effect will instant mine wood and nether wood type blocks.

--- a/src/main/java/gillycarpetaddons/GillyCarpetAddonsServer.java
+++ b/src/main/java/gillycarpetaddons/GillyCarpetAddonsServer.java
@@ -2,7 +2,9 @@ package gillycarpetaddons;
 
 import carpet.CarpetExtension;
 import carpet.CarpetServer;
+import carpet.api.settings.SettingsManager;
 import carpet.utils.Translations;
+import gillycarpetaddons.ruleobservers.movableSpawnerRuleObserver;
 import net.fabricmc.api.ModInitializer;
 
 import java.util.Map;
@@ -15,6 +17,7 @@ public class GillyCarpetAddonsServer implements CarpetExtension, ModInitializer 
 
     @Override
     public void onGameStarted() {
+        SettingsManager.registerGlobalRuleObserver(new movableSpawnerRuleObserver());
         CarpetServer.settingsManager.parseSettingsClass(GillyCarpetAddonsSettings.class);
     }
 

--- a/src/main/java/gillycarpetaddons/GillyCarpetAddonsSettings.java
+++ b/src/main/java/gillycarpetaddons/GillyCarpetAddonsSettings.java
@@ -14,6 +14,9 @@ public class GillyCarpetAddonsSettings {
 
     @Rule(categories = {FEATURE, EXPERIMENTAL, GILLY})
     public static boolean movableEmptyEndPortalFrames = false;
+
+    @Rule(categories = {FEATURE, EXPERIMENTAL, GILLY})
+    public static boolean movableSpawners = false;
   
     @Rule(categories = {SURVIVAL, GILLY})
     public static boolean netheriteAxeInstantMineWood = false;

--- a/src/main/java/gillycarpetaddons/mixins/PistonBlock_MovableSpawnersMixin.java
+++ b/src/main/java/gillycarpetaddons/mixins/PistonBlock_MovableSpawnersMixin.java
@@ -1,0 +1,40 @@
+package gillycarpetaddons.mixins;
+
+import carpet.CarpetSettings;
+import gillycarpetaddons.GillyCarpetAddonsSettings;
+import net.minecraft.block.*;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(PistonBlock.class)
+public abstract class PistonBlock_MovableSpawnersMixin {
+
+    @Inject(
+            method = "isMovable", cancellable = true,
+            at = @At(
+                    value = "TAIL",
+                    shift = At.Shift.BEFORE
+            )
+    )
+    private static void movableSpawners(BlockState blockState_1,
+                                              World world_1,
+                                              BlockPos blockPos_1,
+                                              Direction direction_1,
+                                              boolean boolean_1,
+                                              Direction direction_2,
+                                              CallbackInfoReturnable<Boolean> cir)
+    {
+        Block block_1 = blockState_1.getBlock();
+        // Make spawners movable if rules enabled
+        if (CarpetSettings.movableBlockEntities
+                && GillyCarpetAddonsSettings.movableSpawners
+                && block_1 instanceof SpawnerBlock) {
+            cir.setReturnValue(true);
+        }
+    }
+}

--- a/src/main/java/gillycarpetaddons/ruleobservers/movableSpawnerRuleObserver.java
+++ b/src/main/java/gillycarpetaddons/ruleobservers/movableSpawnerRuleObserver.java
@@ -1,0 +1,36 @@
+package gillycarpetaddons.ruleobservers;
+
+import carpet.CarpetSettings;
+import carpet.api.settings.CarpetRule;
+import carpet.api.settings.InvalidRuleValueException;
+import carpet.api.settings.SettingsManager;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.text.Text;
+
+import java.util.Objects;
+
+public final class movableSpawnerRuleObserver implements SettingsManager.RuleObserver {
+    @Override
+    public void ruleChanged(ServerCommandSource source, CarpetRule<?> changedRule, String userInput) {
+        try {
+            // Using a string here directly feels wrong but likelihood of renaming this rule is low
+            if (!Objects.equals(changedRule.name(), "movableSpawners")) {
+                return;
+            }
+
+            boolean ruleEnabled = (boolean) changedRule.value();
+            if (!ruleEnabled) {
+                return;
+            }
+
+            if (CarpetSettings.movableBlockEntities) {
+                return;
+            }
+
+            source.sendError(Text.of("The carpet rule 'movableBlockEntities' must be enabled to use this rule!"));
+            changedRule.set(source, String.valueOf(false));
+        } catch (InvalidRuleValueException e) {
+           e.notifySource(changedRule.name(), source);
+        }
+    }
+}

--- a/src/main/resources/assets/gilly7ce-carpet-addons/lang/en_us.json
+++ b/src/main/resources/assets/gilly7ce-carpet-addons/lang/en_us.json
@@ -2,7 +2,7 @@
   "carpet.category.gilly7ce_carpet_addons": "gilly7ce-carpet-addons",
   "carpet.rule.dropEyesOfEnderFromEndPortalFrame.desc": "A full end portal frame will drop an eye of ender when right clicked by a player, turning into an empty end portal frame in the process. Any connecting end portals will break.",
   "carpet.rule.movableEmptyEndPortalFrames.desc": "Allows empty end portal frames to be moved.",
-  "carpet.rule.movableSpawners.desc": "Allows spawners to be moved.\n This requires the carpet movableBlockEntities rule to be enabled",
+  "carpet.rule.movableSpawners.desc": "Allows spawners to be moved.\nThis requires the carpet movableBlockEntities rule to be enabled",
   "carpet.rule.netheriteAxeInstantMineWood.desc": "A netherite axe with efficiency V combined with the haste II status effect will instant mine wood and nether wood type blocks.",
   "carpet.rule.netheritePickaxeInstantMineBlueIce.desc": "A netherite pickaxe with efficiency V combined with the haste II status effect will instant mine blue ice blocks.",
   "carpet.rule.netheritePickaxeInstantMineCobblestone.desc": "A netherite pickaxe with efficiency V combined with the haste II status effect will instant mine cobblestone type blocks.",

--- a/src/main/resources/assets/gilly7ce-carpet-addons/lang/en_us.json
+++ b/src/main/resources/assets/gilly7ce-carpet-addons/lang/en_us.json
@@ -2,6 +2,7 @@
   "carpet.category.gilly7ce_carpet_addons": "gilly7ce-carpet-addons",
   "carpet.rule.dropEyesOfEnderFromEndPortalFrame.desc": "A full end portal frame will drop an eye of ender when right clicked by a player, turning into an empty end portal frame in the process. Any connecting end portals will break.",
   "carpet.rule.movableEmptyEndPortalFrames.desc": "Allows empty end portal frames to be moved.",
+  "carpet.rule.movableSpawners.desc": "Allows spawners to be moved.\n This requires the carpet movableBlockEntities rule to be enabled",
   "carpet.rule.netheriteAxeInstantMineWood.desc": "A netherite axe with efficiency V combined with the haste II status effect will instant mine wood and nether wood type blocks.",
   "carpet.rule.netheritePickaxeInstantMineBlueIce.desc": "A netherite pickaxe with efficiency V combined with the haste II status effect will instant mine blue ice blocks.",
   "carpet.rule.netheritePickaxeInstantMineCobblestone.desc": "A netherite pickaxe with efficiency V combined with the haste II status effect will instant mine cobblestone type blocks.",

--- a/src/main/resources/gilly7ce-carpet-addons.mixins.json
+++ b/src/main/resources/gilly7ce-carpet-addons.mixins.json
@@ -9,6 +9,7 @@
     "PistonBlock_MovableEmptyEndPortalFrameMixin",
     "ServerChunkManager_PhantomsObeyHostileMobCapMixin",
     "ServerPlayerEntity_InstantMineMixin",
+    "PistonBlock_MovableSpawnersMixin",
     "invokers.SpawnHelperInfoInvokerMixin"
   ],
   "injectors": {


### PR DESCRIPTION
Allows spawners to be moved by pistons and slimestone. Requires the `movableBlockEntities` rule from carpet to be enabled to work, which is checked when applying the value.

Closes #18 