### PR TITLE
Add creativePlayerOneHitKill rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ You also need to download the [carpet mod](https://github.com/gnembon/fabric-car
 
 ## Features
 
+### creativePlayerOneHitKill
+
+Allows players in Creative mode to kill entities in one hit.
+
+- Type: `boolean`
+- Default value: `false`
+- Required options: `true`, `false`
+- Categories: `FEATURE`, `CREATIVE`, `GILLY7CE-CARPET-ADDON`
+- Additional notes:
+  - This only works on non-player entities.
+
 ### disablePhantomSpawningInMushroomFields
 
 Phantoms will no longer spawn in a mushroom fields biome.

--- a/src/main/java/gillycarpetaddons/GillyCarpetAddonsSettings.java
+++ b/src/main/java/gillycarpetaddons/GillyCarpetAddonsSettings.java
@@ -2,12 +2,13 @@ package gillycarpetaddons;
 
 import carpet.api.settings.Rule;
 
-import static carpet.api.settings.RuleCategory.EXPERIMENTAL;
-import static carpet.api.settings.RuleCategory.FEATURE;
-import static carpet.api.settings.RuleCategory.SURVIVAL;
+import static carpet.api.settings.RuleCategory.*;
 
 public class GillyCarpetAddonsSettings {
     private static final String GILLY = "gilly7ce-carpet-addons";
+
+    @Rule(categories = {FEATURE, CREATIVE, GILLY})
+    public static boolean creativePlayerOneHitKill = false;
 
     @Rule(categories = {FEATURE, GILLY})
     public static boolean disablePhantomSpawningInMushroomFields = false;

--- a/src/main/java/gillycarpetaddons/mixins/PlayerEntity_CreativePlayerOneHitKillMixin.java
+++ b/src/main/java/gillycarpetaddons/mixins/PlayerEntity_CreativePlayerOneHitKillMixin.java
@@ -1,0 +1,87 @@
+package gillycarpetaddons.mixins;
+
+import gillycarpetaddons.GillyCarpetAddonsSettings;
+import gillycarpetaddons.mixins.accessors.EntityAccessorMixin;
+import gillycarpetaddons.mixins.invokers.EntityInvokerMixin;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.boss.dragon.EnderDragonEntity;
+import net.minecraft.entity.boss.dragon.EnderDragonPart;
+import net.minecraft.entity.player.PlayerAbilities;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.predicate.entity.EntityPredicates;
+import net.minecraft.sound.SoundCategory;
+import net.minecraft.sound.SoundEvents;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Arrays;
+
+@Mixin(PlayerEntity.class)
+public abstract class PlayerEntity_CreativePlayerOneHitKillMixin implements EntityAccessorMixin, EntityInvokerMixin {
+    @Shadow
+    @Final
+    private PlayerAbilities abilities;
+
+    @Shadow
+    public abstract SoundCategory getSoundCategory();
+
+    /**
+     * This is adapted from the
+     * <a href="https://github.com/Lunaar-SMP/lunaar-carpet-addons">lunaar carpet extensions mod</a>.
+     * At time of writing this code, the lunaar mod is still in version 1.17 and 1.18 experimental snapshots and I really
+     * wanted this functionality for 1.19+. If this mod will support versions below 1.19, then only 1.18 will include this
+     * carpet rule out of respect for the lunaar mod.
+     */
+    @Inject(
+            method = "attack",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/entity/Entity;handleAttack(Lnet/minecraft/entity/Entity;)Z",
+                    shift = At.Shift.BY,
+                    by = -2
+            ),
+            cancellable = true
+    )
+    public void creativeKill(Entity target, CallbackInfo ci) {
+        World world = this.getWorld();
+        if (!GillyCarpetAddonsSettings.creativePlayerOneHitKill
+                || world.isClient
+                || !this.abilities.creativeMode
+                || !EntityPredicates.EXCEPT_CREATIVE_OR_SPECTATOR.test(target)
+                || target instanceof PlayerEntity) {
+            return;
+        }
+
+        instantKillTarget(target);
+        world.playSound(
+                null,
+                this.invokeGetX(),
+                this.invokeGetY(),
+                this.invokeGetZ(),
+                SoundEvents.ENTITY_PLAYER_ATTACK_CRIT,
+                this.getSoundCategory(),
+                1.0f,
+                1.0f);
+        ci.cancel();
+    }
+
+    private void instantKillTarget(Entity target) {
+        if (target instanceof EnderDragonPart enderDragonPart) {
+            instantKillEnderDragon(enderDragonPart);
+            return;
+        }
+
+        target.kill();
+    }
+
+    private void instantKillEnderDragon(EnderDragonPart enderDragonPart) {
+        EnderDragonEntity enderDragonEntity = enderDragonPart.owner;
+        Arrays.stream(enderDragonEntity.getBodyParts()).forEach(Entity::kill);
+        enderDragonEntity.kill();
+    }
+}

--- a/src/main/java/gillycarpetaddons/mixins/accessors/EntityAccessorMixin.java
+++ b/src/main/java/gillycarpetaddons/mixins/accessors/EntityAccessorMixin.java
@@ -1,0 +1,12 @@
+package gillycarpetaddons.mixins.accessors;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(Entity.class)
+public interface EntityAccessorMixin {
+    @Accessor("world")
+    World getWorld();
+}

--- a/src/main/java/gillycarpetaddons/mixins/invokers/EntityInvokerMixin.java
+++ b/src/main/java/gillycarpetaddons/mixins/invokers/EntityInvokerMixin.java
@@ -1,0 +1,17 @@
+package gillycarpetaddons.mixins.invokers;
+
+import net.minecraft.entity.Entity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(Entity.class)
+public interface EntityInvokerMixin {
+    @Invoker("getX")
+    double invokeGetX();
+
+    @Invoker("getY")
+    double invokeGetY();
+
+    @Invoker("getZ")
+    double invokeGetZ();
+}

--- a/src/main/resources/assets/gilly7ce-carpet-addons/lang/en_us.json
+++ b/src/main/resources/assets/gilly7ce-carpet-addons/lang/en_us.json
@@ -1,5 +1,6 @@
 {
   "carpet.category.gilly7ce_carpet_addons": "gilly7ce-carpet-addons",
+  "carpet.rule.creativePlayerOneHitKill.desc" : "Allows players in Creative mode to kill entities in one hit.",
   "carpet.rule.disablePhantomSpawningInMushroomFields.desc": "Phantoms will no longer spawn in a mushroom fields biome.",
   "carpet.rule.dropEyesOfEnderFromEndPortalFrame.desc": "A full end portal frame will drop an eye of ender when right clicked by a player, turning into an empty end portal frame in the process. Any connecting end portals will break.",
   "carpet.rule.movableEmptyEndPortalFrames.desc": "Allows empty end portal frames to be moved.",

--- a/src/main/resources/gilly7ce-carpet-addons.mixins.json
+++ b/src/main/resources/gilly7ce-carpet-addons.mixins.json
@@ -7,10 +7,13 @@
     "EndFrameBlock_EyeToggleMixin",
     "PhantomSpawnerMixin",
     "PistonBlock_MovableEmptyEndPortalFrameMixin",
+    "PistonBlock_MovableSpawnersMixin",
+    "PlayerEntity_CreativePlayerOneHitKillMixin",
     "ServerChunkManager_PhantomsObeyHostileMobCapMixin",
     "ServerPlayerEntity_InstantMineMixin",
     "ServerPlayerEntity_SpectatorPlayersUsePortalsMixin",
-    "PistonBlock_MovableSpawnersMixin",
+    "accessors.EntityAccessorMixin",
+    "invokers.EntityInvokerMixin",
     "invokers.SpawnHelperInfoInvokerMixin"
   ],
   "injectors": {


### PR DESCRIPTION
New rule `creativePlayerOneHitKill`.

Adapted from the lunaar mod. Rule allows players to one hit kill entities. Will not work on other players who are in survival mode to avoid abusing the rule.

Closes #16 