### PR TITLE
Add new option 'drop_as_items_on_explosion' to movableEmptyEndPortalFrames rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,13 @@ A full end portal frame will drop an eye of ender when right clicked by a player
 
 ### movableEmptyEndPortalFrames
 
-Allows empty end portal frames to be moved.
+Allows empty end portal frames to be moved. 
+The `drop_as_items_on_explosion` option will allow end portal frames to drop as items when an explosion occurs whilst
+being pushed by a piston.
 
-- Type: `boolean`
+- Type: `MovableBlockOptions`
 - Default value: `false`
-- Required options: `true`, `false`
+- Required options: `true`, `false`, `drop_as_items_on_explosion`
 - Categories: `FEATURE`, `EXPERIMENTAL`, `GILLY7CE-CARPET-ADDON`
 
 ### movableSpawners

--- a/src/main/java/gillycarpetaddons/GillyCarpetAddonsSettings.java
+++ b/src/main/java/gillycarpetaddons/GillyCarpetAddonsSettings.java
@@ -16,7 +16,7 @@ public class GillyCarpetAddonsSettings {
     public static boolean dropEyesOfEnderFromEndPortalFrame = false;
 
     @Rule(categories = {FEATURE, EXPERIMENTAL, GILLY})
-    public static boolean movableEmptyEndPortalFrames = false;
+    public static MovableBlockOptions movableEmptyEndPortalFrames = MovableBlockOptions.FALSE;
 
     @Rule(categories = {FEATURE, EXPERIMENTAL, GILLY})
     public static boolean movableSpawners = false;
@@ -44,4 +44,10 @@ public class GillyCarpetAddonsSettings {
 
     @Rule(categories = {FEATURE,EXPERIMENTAL,GILLY})
     public static boolean spectatorPlayersUsePortals = false;
+
+    public enum MovableBlockOptions {
+        TRUE(),
+        FALSE(),
+        DROP_AS_ITEM_ON_EXPLOSION();
+    }
 }

--- a/src/main/java/gillycarpetaddons/mixins/PistonBlock_MovableEmptyEndPortalFrameMixin.java
+++ b/src/main/java/gillycarpetaddons/mixins/PistonBlock_MovableEmptyEndPortalFrameMixin.java
@@ -8,6 +8,8 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
+import java.util.Objects;
+
 @Mixin(PistonBlock.class)
 public class PistonBlock_MovableEmptyEndPortalFrameMixin {
     @Redirect(
@@ -19,7 +21,7 @@ public class PistonBlock_MovableEmptyEndPortalFrameMixin {
     private static float getHardnessRedirect(BlockState instance, BlockView blockView, BlockPos blockPos) {
         Block currentBlock = instance.getBlock();
         // Only allow empty end portal frames to be moved
-        if (GillyCarpetAddonsSettings.movableEmptyEndPortalFrames
+        if (GillyCarpetAddonsSettings.movableEmptyEndPortalFrames != GillyCarpetAddonsSettings.MovableBlockOptions.FALSE
                 && currentBlock == Blocks.END_PORTAL_FRAME
                 && !instance.get(EndPortalFrameBlock.EYE)) {
             // If hardness is -1.0f then the piston cannot be moved. This is the vanilla behaviour for end portal frames

--- a/src/main/java/gillycarpetaddons/mixins/PistonBlock_MovableEmptyEndPortalFrameMixin.java
+++ b/src/main/java/gillycarpetaddons/mixins/PistonBlock_MovableEmptyEndPortalFrameMixin.java
@@ -8,8 +8,6 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
-import java.util.Objects;
-
 @Mixin(PistonBlock.class)
 public class PistonBlock_MovableEmptyEndPortalFrameMixin {
     @Redirect(

--- a/src/main/java/gillycarpetaddons/mixins/PistonExtensionBlock_MovableEmptyEndPortalFrameMixin.java
+++ b/src/main/java/gillycarpetaddons/mixins/PistonExtensionBlock_MovableEmptyEndPortalFrameMixin.java
@@ -37,7 +37,7 @@ public abstract class PistonExtensionBlock_MovableEmptyEndPortalFrameMixin {
             return;
         }
 
-        var droppedStacks = Collections.singletonList(new ItemStack(Items.END_PORTAL_FRAME));
+        List<ItemStack> droppedStacks = Collections.singletonList(new ItemStack(Items.END_PORTAL_FRAME));
         cir.setReturnValue(droppedStacks);
     }
 }

--- a/src/main/java/gillycarpetaddons/mixins/PistonExtensionBlock_MovableEmptyEndPortalFrameMixin.java
+++ b/src/main/java/gillycarpetaddons/mixins/PistonExtensionBlock_MovableEmptyEndPortalFrameMixin.java
@@ -1,0 +1,43 @@
+package gillycarpetaddons.mixins;
+
+import gillycarpetaddons.GillyCarpetAddonsSettings;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.PistonExtensionBlock;
+import net.minecraft.block.entity.PistonBlockEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.loot.context.LootContext;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+import java.util.*;
+
+@Mixin(PistonExtensionBlock.class)
+public abstract class PistonExtensionBlock_MovableEmptyEndPortalFrameMixin {
+    @Inject(
+            method = "getDroppedStacks",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/block/entity/PistonBlockEntity;getPushedBlock()Lnet/minecraft/block/BlockState;"
+            ),
+            locals = LocalCapture.CAPTURE_FAILHARD,
+            cancellable = true)
+    private void getDroppedStacksForMovableBlock(BlockState state,
+                                                 LootContext.Builder builder,
+                                                 CallbackInfoReturnable<List<ItemStack>> cir,
+                                                 PistonBlockEntity pistonBlockEntity) {
+        Block pushedBlock = pistonBlockEntity.getPushedBlock().getBlock();
+        if (GillyCarpetAddonsSettings.movableEmptyEndPortalFrames != GillyCarpetAddonsSettings.MovableBlockOptions.DROP_AS_ITEM_ON_EXPLOSION
+                || pushedBlock != Blocks.END_PORTAL_FRAME) {
+            return;
+        }
+
+        var droppedStacks = Collections.singletonList(new ItemStack(Items.END_PORTAL_FRAME));
+        cir.setReturnValue(droppedStacks);
+    }
+}

--- a/src/main/resources/assets/gilly7ce-carpet-addons/lang/en_us.json
+++ b/src/main/resources/assets/gilly7ce-carpet-addons/lang/en_us.json
@@ -2,7 +2,7 @@
   "carpet.category.gilly7ce_carpet_addons": "gilly7ce-carpet-addons",
   "carpet.rule.disablePhantomSpawningInMushroomFields.desc": "Phantoms will no longer spawn in a mushroom fields biome.",
   "carpet.rule.dropEyesOfEnderFromEndPortalFrame.desc": "A full end portal frame will drop an eye of ender when right clicked by a player, turning into an empty end portal frame in the process. Any connecting end portals will break.",
-  "carpet.rule.movableEmptyEndPortalFrames.desc": "Allows empty end portal frames to be moved.",
+  "carpet.rule.movableEmptyEndPortalFrames.desc": "Allows empty end portal frames to be moved.\nThe `drop_as_items_on_explosion` option will allow end portal frames to drop as items when an explosion occurs whilst being pushed by a piston.",
   "carpet.rule.movableSpawners.desc": "Allows spawners to be moved.\nThis requires the carpet movableBlockEntities rule to be enabled",
   "carpet.rule.netheriteAxeInstantMineWood.desc": "A netherite axe with efficiency V combined with the haste II status effect will instant mine wood and nether wood type blocks.",
   "carpet.rule.netheritePickaxeInstantMineBlueIce.desc": "A netherite pickaxe with efficiency V combined with the haste II status effect will instant mine blue ice blocks.",

--- a/src/main/resources/gilly7ce-carpet-addons.mixins.json
+++ b/src/main/resources/gilly7ce-carpet-addons.mixins.json
@@ -7,10 +7,11 @@
     "EndFrameBlock_EyeToggleMixin",
     "PhantomSpawnerMixin",
     "PistonBlock_MovableEmptyEndPortalFrameMixin",
+    "PistonBlock_MovableSpawnersMixin",
+    "PistonExtensionBlock_MovableEmptyEndPortalFrameMixin",
     "ServerChunkManager_PhantomsObeyHostileMobCapMixin",
     "ServerPlayerEntity_InstantMineMixin",
     "ServerPlayerEntity_SpectatorPlayersUsePortalsMixin",
-    "PistonBlock_MovableSpawnersMixin",
     "invokers.SpawnHelperInfoInvokerMixin"
   ],
   "injectors": {


### PR DESCRIPTION
With this option enabled, an end portal frame can drop as an item if destroyed by tnt whilst being pushed by a piston.

Closes #55 