### PR TITLE
Refactor PistonBlock_MovableEmptyEndPortalFrameMixin to fix bug #57

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.12.8
 
 # Mod Properties
-	mod_version = 0.3.0
+	mod_version = 0.3.1
 	maven_group = gilly7ce-carpet-addons
 	archives_base_name = gilly7ce-carpet-addons
 

--- a/src/main/java/gillycarpetaddons/mixins/PistonBlock_MovableEmptyEndPortalFrameMixin.java
+++ b/src/main/java/gillycarpetaddons/mixins/PistonBlock_MovableEmptyEndPortalFrameMixin.java
@@ -3,31 +3,41 @@ package gillycarpetaddons.mixins;
 import gillycarpetaddons.GillyCarpetAddonsSettings;
 import net.minecraft.block.*;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.BlockView;
+import net.minecraft.util.math.Direction;
+import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(PistonBlock.class)
 public class PistonBlock_MovableEmptyEndPortalFrameMixin {
-    @Redirect(
+    /**
+     * This was originally a redirect but that made the mod incompatible with the
+     * carpet-fixes mod. So instead of redirecting the getHardness method, we're
+     * simply injecting the behavior before it is called. If the block is an empty
+     * end portal and the rule is enabled, it will be movable.
+     */
+    @Inject(
             method = "isMovable",
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/block/BlockState;getHardness(Lnet/minecraft/world/BlockView;Lnet/minecraft/util/math/BlockPos;)F"
-            ))
-    private static float getHardnessRedirect(BlockState instance, BlockView blockView, BlockPos blockPos) {
-        Block currentBlock = instance.getBlock();
+            ),
+            cancellable = true)
+    private static void isMovableEmptyEndPortalFrame(BlockState state,
+                                                     World world,
+                                                     BlockPos pos,
+                                                     Direction direction,
+                                                     boolean canBreak,
+                                                     Direction pistonDir,
+                                                     CallbackInfoReturnable<Boolean> cir) {
+        Block currentBlock = state.getBlock();
         // Only allow empty end portal frames to be moved
         if (GillyCarpetAddonsSettings.movableEmptyEndPortalFrames
                 && currentBlock == Blocks.END_PORTAL_FRAME
-                && !instance.get(EndPortalFrameBlock.EYE)) {
-            // If hardness is -1.0f then the piston cannot be moved. This is the vanilla behaviour for end portal frames
-            // which matches with the bedrock block. Instead of overriding the hardness for end portal frames everywhere,
-            // just do it when it is called inside the PistonBlock.
-            return 0f;
+                && !state.get(EndPortalFrameBlock.EYE)) {
+            cir.setReturnValue(true);
         }
-
-        return instance.getHardness(blockView, blockPos);
     }
 }


### PR DESCRIPTION
The `getHardnessRedirect `method has been refactored from a redirect to an injection with the name `isMovableEmptyEndPortalFrame`. This is called before `getHardness `is called in `PistonBlock.isMovable` and if the rule is enabled and the block meets the criteria it shall be movable.

This has technically made the code simpler anyway, so that's nice.

Bumps mod version to 0.3.1