### PR TITLE
Update carpet to latest 1.19.3 version (1.4.96)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,5 +12,5 @@ archives_base_name=gilly7ce-carpet-addons
 # Dependencies
 # currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
 # fabric_version=0.25.1+build.416-1.16
-carpet_core_version=1.4.91+v221207
+carpet_core_version=1.4.96+v230201
 carpet_minecraft_version=1.19.3

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -26,7 +26,7 @@
     "fabricloader": ">=0.14.19",
     "minecraft": "1.19.*",
     "java": ">=17",
-    "carpet": ">=1.4.91"
+    "carpet": ">=1.4.96"
   },
   "suggests": {},
   "custom": {


### PR DESCRIPTION
Bumps carpet version to latest supported for 1.19.3. Enforcing this will ensure anyone who consumes 1.19.3 of this mod will be using the appropriate carpet version.