### PR TITLE
Update minecraft version to 1.19.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ bin/
 # fabric
 
 run/
+remappedSrc/

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://fabricmc.net/use
-minecraft_version=1.19.3
-yarn_mappings=1.19.3+build.5
+minecraft_version=1.19.4
+yarn_mappings=1.19.4+build.2
 loader_version=0.14.19
 # Mod Properties
 mod_version=1.0.0-beta.3
@@ -12,5 +12,5 @@ archives_base_name=gilly7ce-carpet-addons
 # Dependencies
 # currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
 # fabric_version=0.25.1+build.416-1.16
-carpet_core_version=1.4.96+v230201
-carpet_minecraft_version=1.19.3
+carpet_core_version=1.4.101+v230319
+carpet_minecraft_version=1.19.4

--- a/src/main/java/gillycarpetaddons/mixins/PhantomSpawnerMixin.java
+++ b/src/main/java/gillycarpetaddons/mixins/PhantomSpawnerMixin.java
@@ -73,8 +73,8 @@ public abstract class PhantomSpawnerMixin {
                            "(Lnet/minecraft/entity/Entity;)V"
           )
   )
-  private void isInMooshromBiome(ServerWorld instance, Entity entity) {
-    BlockPos pos = new BlockPos(entity.getPos());
+  private void isInMushroomFieldsBiome(ServerWorld instance, Entity entity) {
+    BlockPos pos = entity.getBlockPos();
     RegistryEntry<Biome> registryEntry = instance.getBiome(pos);
     if (!GillyCarpetAddonsSettings.disablePhantomSpawningInMushroomFields ||
         registryEntry.getKey().get() != BiomeKeys.MUSHROOM_FIELDS) {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,9 +24,9 @@
   ],
   "depends": {
     "fabricloader": ">=0.14.19",
-    "minecraft": "1.19.*",
+    "minecraft": "1.19.4",
     "java": ">=17",
-    "carpet": ">=1.4.96"
+    "carpet": ">=1.4.101"
   },
   "suggests": {},
   "custom": {


### PR DESCRIPTION
Provides support for the latest version of Minecraft at time of writing, which is 1.19.4.

Only code change required is in `PhantomSpawnerMixin`, where a `BlockPos` object was being instantiated. The constructor being used has been removed in 1.19.4. The fix is to use the `Entity.getBlockPos` method as that is essentially all that was being done in the code snippet anyway.

Also updates carpet to latest supported version for 1.19.4, which is 1.4.101+v230319.

Closes #47 