### PR TITLE
Fix `creativePlayerOneHitKill` from destroying item frames

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ minecraft_version=1.19.4
 yarn_mappings=1.19.4+build.2
 loader_version=0.14.19
 # Mod Properties
-mod_version=1.0.0
+mod_version=1.0.1
 maven_group=gilly7ce-carpet-addons
 archives_base_name=gilly7ce-carpet-addons
 # Dependencies


### PR DESCRIPTION
Item frames (including glowing ones) will no longer be subject to the rule.

Closes #92